### PR TITLE
iOS: Topic picker without horizontal scrolling (#12)

### DIFF
--- a/features/FEATURE_REGISTRY.md
+++ b/features/FEATURE_REGISTRY.md
@@ -15,7 +15,7 @@ It is intentionally lightweight: update it whenever you ship meaningful progress
 
 | Area | BDD spec | Implementation entry points | Status | Notes |
 | --- | --- | --- | --- | --- |
-| Home & topic selection | `features/home/home.feature` | `ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/HomeView.swift`, `Models.swift` | Implemented | Includes preset topics, surprise topic, custom topic + empty validation. |
+| Home & topic selection | `features/home/home.feature` | `ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/HomeView.swift`, `Models.swift` | Implemented | Includes preset topics (no horizontal scrolling), surprise topic, custom topic + empty validation. |
 | First-run onboarding | `features/onboarding/onboarding.feature` | `ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/OnboardingView.swift`, `AppModel.swift` | Implemented | Persists onboarding completion + selected values in `UserDefaults`. |
 | Settings (Realtime model) | `features/settings/settings.feature` | `ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift`, `AppModel.swift`, `TokenService.swift`, `api/realtime/token.js` | Implemented (UI only) | UI + persistence are implemented; verify that sessions use the selected model end-to-end. |
 | Settings (Learner context) | `features/settings/settings.feature` | `ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift`, `AppModel.swift`, `LearnerContext.swift`, `OpenAIWebRTCSession.swift` | Implemented (UI only) | UI + persistence are implemented; session instructions include learner context via `session.update`; verify end-to-end behavior. |

--- a/features/home/home.feature
+++ b/features/home/home.feature
@@ -39,3 +39,11 @@ Feature: Home and topic selection
     When I specify a topic as ""
     Then I should see a validation message
     And I should remain on the home screen
+
+  @HO-006 @mvp
+  Scenario: Topics are visible without horizontal scrolling
+    Given I am on the home screen
+    Then I should be able to see all preset topics at a glance without horizontal scrolling
+    And the selected topic state should be clear and consistent
+    And Surprise and Custom topic should still be available
+    And the layout should work with larger text sizes without clipping

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/HomeView.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/HomeView.swift
@@ -70,20 +70,20 @@ struct HomeView: View {
             Text("Topic")
                 .font(.headline)
 
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 10) {
-                    ForEach(Topic.presets) { topic in
-                        TopicChip(title: topic.title, isSelected: appModel.selectedTopic == topic) {
-                            appModel.selectedTopic = topic
-                        }
-                    }
+            let columns: [GridItem] = [GridItem(.adaptive(minimum: 120), spacing: 10, alignment: .leading)]
 
-                    TopicChip(title: "Surprise", isSelected: false) {
-                        appModel.selectedTopic = surpriseTopics.randomElement()
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 10) {
+                ForEach(Topic.presets) { topic in
+                    TopicChip(title: topic.title, isSelected: appModel.selectedTopic == topic) {
+                        appModel.selectedTopic = topic
                     }
                 }
-                .padding(.vertical, 4)
+
+                TopicChip(title: "Surprise", isSelected: false) {
+                    appModel.selectedTopic = surpriseTopics.randomElement()
+                }
             }
+            .padding(.vertical, 4)
 
             HStack(spacing: 8) {
                 TextField("Custom topic (e.g. Space)", text: $customTopicText)
@@ -117,10 +117,14 @@ private struct TopicChip: View {
         Button(action: onTap) {
             Text(title)
                 .font(.subheadline.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, minHeight: 36)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
         }
         .buttonStyle(.bordered)
         .tint(isSelected ? .blue : .gray)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }


### PR DESCRIPTION
Closes #12.

## What changed
- Replaced the horizontal ScrollView topic chips on Home with an adaptive grid so topics wrap across multiple lines.
- Kept selection, Surprise, and Custom topic behaviors intact.
- Updated BDD spec for non-scrolling discoverability and Dynamic Type expectations.

## Verification
- xcodebuild Debug build for iOS Simulator succeeded (iPhone 17, iOS 26.2).