### PR TITLE
Protect /api/realtime/token with shared secret (MVP)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # Copy to .env and fill in values
 OPENAI_API_KEY=""
+
+# Required: shared secret to protect /api/realtime/token from unauthenticated use.
+# NOTE: This is MVP protection (a determined attacker can extract it from a shipped app).
+TOKEN_SERVICE_SHARED_SECRET=""
+
 REALTIME_EPHEMERAL_TTL_SECONDS=600
 REALTIME_VOICE="alloy"
 

--- a/docs/backend-vercel.md
+++ b/docs/backend-vercel.md
@@ -13,11 +13,23 @@ This repo includes a minimal Vercel backend to mint **ephemeral Realtime client 
 - `GET /api/health` → `{ ok: true }`
 - `GET /api/realtime/token?topic=Space` → `{ value, expires_at, session }`
 
+### Authentication (MVP shared secret)
+
+`/api/realtime/token` is protected by a shared secret to prevent unauthenticated token minting.
+
+Clients must send **either**:
+
+- `X-Token-Service-Secret: <secret>`
+- `Authorization: Bearer <secret>`
+
+Requests with a missing/invalid secret return **401**.
+
 ## Environment variables
 
 Create `.env` (or configure Vercel Project Env Vars):
 
 - `OPENAI_API_KEY` (required)
+- `TOKEN_SERVICE_SHARED_SECRET` (required) — shared secret to protect `/api/realtime/token`
 - `REALTIME_EPHEMERAL_TTL_SECONDS` (optional, default 600)
 - `REALTIME_VOICE` (optional, default `alloy`)
 - `REALTIME_TOKEN_RPM` (optional, default 30) — best-effort per-instance rate limit
@@ -33,10 +45,11 @@ Typical local flow:
   Link to an existing project name like `language-speaking-trainer`.
 3. Start local dev with `vercel dev` and test:
   `GET http://127.0.0.1:3000/api/health`
-  `GET http://127.0.0.1:3000/api/realtime/token?topic=Space`
+  `GET http://127.0.0.1:3000/api/realtime/token?topic=Space` (requires secret header)
 
 ## iOS configuration
 
 In the iOS app `Info.plist`, set:
 
 - `TOKEN_SERVICE_BASE_URL` to your Vercel deployment URL (e.g. `https://your-vercel-app.vercel.app`).
+- `TOKEN_SERVICE_SHARED_SECRET` to the same value as `TOKEN_SERVICE_SHARED_SECRET` on the backend.

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer.xcodeproj/project.pbxproj
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TOKEN_SERVICE_BASE_URL = "https://language-speaking-trainer.vercel.app";
+				TOKEN_SERVICE_SHARED_SECRET = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -342,6 +343,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TOKEN_SERVICE_BASE_URL = "https://language-speaking-trainer.vercel.app";
+				TOKEN_SERVICE_SHARED_SECRET = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/AppConfig.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/AppConfig.swift
@@ -11,4 +11,16 @@ enum AppConfig {
         }
         return URL(string: raw)
     }
+
+    /// Shared secret sent to the token service to protect /api/realtime/token.
+    /// NOTE: This is only MVP protection for a single-user / non-public deployment.
+    static var tokenServiceSharedSecret: String? {
+        guard
+            let raw = Bundle.main.object(forInfoDictionaryKey: "TOKEN_SERVICE_SHARED_SECRET") as? String,
+            !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/LanguageSpeakingTrainer-Info.plist
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/LanguageSpeakingTrainer-Info.plist
@@ -27,6 +27,9 @@
 	<key>TOKEN_SERVICE_BASE_URL</key>
 	<string>$(TOKEN_SERVICE_BASE_URL)</string>
 
+	<key>TOKEN_SERVICE_SHARED_SECRET</key>
+	<string>$(TOKEN_SERVICE_SHARED_SECRET)</string>
+
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/TokenService.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/TokenService.swift
@@ -7,6 +7,7 @@ struct EphemeralTokenResponse: Decodable {
 
 enum TokenServiceError: Error {
     case missingBaseURL
+    case missingSharedSecret
     case invalidResponse
     case httpError(status: Int, body: String)
 }
@@ -16,6 +17,8 @@ extension TokenServiceError: LocalizedError {
         switch self {
         case .missingBaseURL:
             return "Missing TOKEN_SERVICE_BASE_URL"
+        case .missingSharedSecret:
+            return "Missing TOKEN_SERVICE_SHARED_SECRET"
         case .invalidResponse:
             return "Invalid response from token service"
         case .httpError(let status, let body):
@@ -34,6 +37,10 @@ enum TokenService {
     ) async throws -> EphemeralTokenResponse {
         guard let base = AppConfig.tokenServiceBaseURL else {
             throw TokenServiceError.missingBaseURL
+        }
+
+        guard let sharedSecret = AppConfig.tokenServiceSharedSecret else {
+            throw TokenServiceError.missingSharedSecret
         }
 
         // NOTE: Do not include a leading "/" in `appendingPathComponent`.
@@ -57,6 +64,7 @@ enum TokenService {
         var req = URLRequest(url: url)
         req.httpMethod = "GET"
         req.cachePolicy = .reloadIgnoringLocalCacheData
+        req.setValue(sharedSecret, forHTTPHeaderField: "X-Token-Service-Secret")
 
         let (data, resp) = try await URLSession.shared.data(for: req)
         guard let http = resp as? HTTPURLResponse else {

--- a/ios/Info.plist.template
+++ b/ios/Info.plist.template
@@ -4,5 +4,11 @@
 <dict>
   <key>NSMicrophoneUsageDescription</key>
   <string>We use the microphone so you can practice speaking English with your virtual teacher.</string>
+
+  <key>TOKEN_SERVICE_BASE_URL</key>
+  <string>$(TOKEN_SERVICE_BASE_URL)</string>
+
+  <key>TOKEN_SERVICE_SHARED_SECRET</key>
+  <string>$(TOKEN_SERVICE_SHARED_SECRET)</string>
 </dict>
 </plist>

--- a/ios/LanguageSpeakingTrainer/AppConfig.swift
+++ b/ios/LanguageSpeakingTrainer/AppConfig.swift
@@ -14,4 +14,16 @@ enum AppConfig {
         }
         return URL(string: raw)
     }
+
+    /// Shared secret sent to the token service to protect /api/realtime/token.
+    /// NOTE: This is only MVP protection for a single-user / non-public deployment.
+    static var tokenServiceSharedSecret: String? {
+        guard
+            let raw = Bundle.main.object(forInfoDictionaryKey: "TOKEN_SERVICE_SHARED_SECRET") as? String,
+            !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }

--- a/ios/LanguageSpeakingTrainer/TokenService.swift
+++ b/ios/LanguageSpeakingTrainer/TokenService.swift
@@ -7,6 +7,7 @@ struct EphemeralTokenResponse: Decodable {
 
 enum TokenServiceError: Error {
     case missingBaseURL
+    case missingSharedSecret
     case invalidResponse
     case httpError(status: Int, body: String)
 }
@@ -16,6 +17,8 @@ extension TokenServiceError: LocalizedError {
         switch self {
         case .missingBaseURL:
             return "Missing TOKEN_SERVICE_BASE_URL"
+        case .missingSharedSecret:
+            return "Missing TOKEN_SERVICE_SHARED_SECRET"
         case .invalidResponse:
             return "Invalid response from token service"
         case .httpError(let status, let body):
@@ -34,6 +37,10 @@ enum TokenService {
     static func fetchEphemeralToken(topic: Topic?) async throws -> EphemeralTokenResponse {
         guard let base = AppConfig.tokenServiceBaseURL else {
             throw TokenServiceError.missingBaseURL
+        }
+
+        guard let sharedSecret = AppConfig.tokenServiceSharedSecret else {
+            throw TokenServiceError.missingSharedSecret
         }
 
         // NOTE: Do not include a leading "/" in `appendingPathComponent`.
@@ -55,6 +62,7 @@ enum TokenService {
         var req = URLRequest(url: url)
         req.httpMethod = "GET"
         req.cachePolicy = .reloadIgnoringLocalCacheData
+        req.setValue(sharedSecret, forHTTPHeaderField: "X-Token-Service-Secret")
 
         let (data, resp) = try await URLSession.shared.data(for: req)
         guard let http = resp as? HTTPURLResponse else {

--- a/ios/README.md
+++ b/ios/README.md
@@ -30,6 +30,9 @@ Template value suggestion:
 Optional (for later Realtime token minting):
 
 - `TOKEN_SERVICE_BASE_URL`: `https://your-vercel-app.vercel.app`
+- `TOKEN_SERVICE_SHARED_SECRET`: a shared secret that the backend requires on `/api/realtime/token`
+
+Note: This is MVP protection suitable for a single-user/private deployment. For a public app, a shipped secret can be extracted.
 
 Note: there is an older scaffold folder at `ios/LanguageSpeakingTrainer/` from before the `.xcodeproj` existed. The canonical sources going forward are the ones inside the Xcode project folder under `ios/App/...`.
 


### PR DESCRIPTION
Closes #17.

## What
- Protects GET /api/realtime/token with a shared secret header.
- Requires TOKEN_SERVICE_SHARED_SECRET env var on Vercel.
- iOS reads TOKEN_SERVICE_SHARED_SECRET from Info.plist and sends it as X-Token-Service-Secret.

## Behavior
- Missing/invalid secret -> 401
- Valid secret -> token minting continues (subject to OpenAI response)

## Docs
- Updated docs/backend-vercel.md, ios/README.md, and .env.example.
