### PR TITLE
Optimize topicPicker grid columns reuse

### DIFF
--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/HomeView.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/HomeView.swift
@@ -8,6 +8,10 @@ struct HomeView: View {
 
     private let surpriseTopics: [Topic] = Topic.presets
 
+    private static let topicGridColumns: [GridItem] = [
+        GridItem(.adaptive(minimum: 120), spacing: 10, alignment: .leading)
+    ]
+
     var body: some View {
         VStack(spacing: 16) {
             VStack(spacing: 8) {
@@ -70,9 +74,7 @@ struct HomeView: View {
             Text("Topic")
                 .font(.headline)
 
-            let columns: [GridItem] = [GridItem(.adaptive(minimum: 120), spacing: 10, alignment: .leading)]
-
-            LazyVGrid(columns: columns, alignment: .leading, spacing: 10) {
+            LazyVGrid(columns: Self.topicGridColumns, alignment: .leading, spacing: 10) {
                 ForEach(Topic.presets) { topic in
                     TopicChip(title: topic.title, isSelected: appModel.selectedTopic == topic) {
                         appModel.selectedTopic = topic


### PR DESCRIPTION
This is a clean replacement for PR #18.

### What
- Avoid re-allocating the `LazyVGrid` column configuration on each `topicPicker` access by storing it as a static `topicGridColumns`.

### Why
- Small micro-optimization and slightly cleaner code. No behavior/UI changes intended.

### Scope
- Single-file change: `ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/HomeView.swift`

### Verification
- iOS simulator build: **BUILD SUCCEEDED**

Supersedes: #18