### PR TITLE
iOS: replace onboarding with Settings (first launch sheet)

### DIFF
--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/RootView.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/RootView.swift
@@ -2,16 +2,42 @@ import SwiftUI
 
 struct RootView: View {
     @EnvironmentObject private var appModel: AppModel
+    @State private var isShowingInitialSettings: Bool = false
 
     var body: some View {
-        Group {
-            if appModel.onboarding.isCompleted {
-                NavigationStack {
-                    HomeView()
-                }
-            } else {
-                OnboardingView()
+        NavigationStack {
+            HomeView()
+        }
+        .sheet(isPresented: $isShowingInitialSettings, onDismiss: {
+            appModel.markInitialSetupCompleteIfNeeded()
+        }) {
+            InitialSettingsSheet(isPresented: $isShowingInitialSettings)
+                .environmentObject(appModel)
+        }
+        .task {
+            // Replace onboarding with a one-time Settings sheet so the user has an obvious
+            // path to configure the learner context without blocking the main UI.
+            if !appModel.onboarding.isCompleted {
+                isShowingInitialSettings = true
             }
+        }
+    }
+}
+
+private struct InitialSettingsSheet: View {
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        NavigationStack {
+            SettingsView()
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Done") {
+                            isPresented = false
+                        }
+                        .accessibilityIdentifier("settings.done")
+                    }
+                }
         }
     }
 }

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift
@@ -26,6 +26,22 @@ struct SettingsView: View {
             }
 
             Section {
+                Picker("Age band", selection: ageBandBinding) {
+                    ForEach(AgeBand.allCases) { band in
+                        Text(band.displayName).tag(band)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("settings.ageBand")
+
+                Picker("English level", selection: englishLevelBinding) {
+                    ForEach(EnglishLevel.allCases) { level in
+                        Text(level.displayName).tag(level)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("settings.englishLevel")
+
                 TextField("Age (4–16)", text: $ageText)
                     .keyboardType(.numberPad)
                     .focused($isAgeFieldFocused)
@@ -93,6 +109,28 @@ struct SettingsView: View {
         .onAppear {
             ageText = appModel.learnerProfile.age.map(String.init) ?? ""
         }
+    }
+
+    private var ageBandBinding: Binding<AgeBand> {
+        Binding(
+            get: { appModel.onboarding.ageBand ?? .earlyElementary },
+            set: { newValue in
+                var o = appModel.onboarding
+                o.ageBand = newValue
+                appModel.onboarding = o
+            }
+        )
+    }
+
+    private var englishLevelBinding: Binding<EnglishLevel> {
+        Binding(
+            get: { appModel.onboarding.englishLevel ?? .beginner },
+            set: { newValue in
+                var o = appModel.onboarding
+                o.englishLevel = newValue
+                appModel.onboarding = o
+            }
+        )
     }
 
     private var schoolTypeRawBinding: Binding<String> {

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainerUITests/LanguageSpeakingTrainerUITests.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainerUITests/LanguageSpeakingTrainerUITests.swift
@@ -1,38 +1,21 @@
 import XCTest
 
 final class LanguageSpeakingTrainerUITests: XCTestCase {
-    func testHappyPath_onboarding_chooseTopic_start_end() {
+    func testHappyPath_chooseTopic_start_end() {
         // Scenario mapping (for spec coverage):
-        // @ON-001 @HO-001 @SE-001
+        // @HO-001 @SE-001
 
         let app = XCUIApplication()
         app.launchEnvironment["UITESTING"] = "1"
         app.launchEnvironment["RESET_STATE"] = "1"
         app.launch()
 
-        // Onboarding: select required values (age band + English level) and wait for Continue
-        // to become enabled before tapping.
-        let ageBand = app.segmentedControls["onboarding.ageBand"]
-        let englishLevel = app.segmentedControls["onboarding.englishLevel"]
-        XCTAssertTrue(ageBand.waitForExistence(timeout: 5))
-        XCTAssertTrue(englishLevel.waitForExistence(timeout: 5))
-
-        // Even though the UI preselects defaults onAppear, CI can be fast enough that
-        // we tap Continue before state is set. Explicitly tapping an option makes the
-        // flow deterministic.
-        if ageBand.buttons.count > 0 {
-            ageBand.buttons.element(boundBy: 0).tap()
+        // First launch shows Settings instead of a dedicated onboarding screen.
+        // If it appears, dismiss it deterministically.
+        let doneButton = app.buttons["settings.done"]
+        if doneButton.waitForExistence(timeout: 5) {
+            doneButton.tap()
         }
-        if englishLevel.buttons.count > 0 {
-            englishLevel.buttons.element(boundBy: 0).tap()
-        }
-
-        let continueButton = app.buttons["onboarding.continue"]
-        XCTAssertTrue(continueButton.waitForExistence(timeout: 5))
-        let continueReady = NSPredicate(format: "exists == true && enabled == true && hittable == true")
-        expectation(for: continueReady, evaluatedWith: continueButton)
-        waitForExpectations(timeout: 5)
-        continueButton.tap()
 
         XCTAssertTrue(app.buttons["home.topic.animals"].waitForExistence(timeout: 5))
         app.buttons["home.topic.animals"].tap()


### PR DESCRIPTION
Fixes #29.

## What changed
- Removed the onboarding gate: app now goes straight to Home.
- On first launch, present Settings as a one-time sheet with a **Done** button.
- Moved former onboarding fields (Age band + English level) into Settings so they remain editable.
- Updated UI test to dismiss the initial Settings sheet and proceed with the happy path.

## How to verify
- Build: iOS Simulator (Debug)
- Tests: `xcodebuild test` (LanguageSpeakingTrainer scheme)

## Notes
- `OnboardingSettings` is retained as the persistence mechanism for learner basics (age band + English level), but the dedicated onboarding screen is no longer shown.