### PR TITLE
iOS: remove former onboarding fields from Settings

### DIFF
--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift
@@ -26,22 +26,6 @@ struct SettingsView: View {
             }
 
             Section {
-                Picker("Age band", selection: ageBandBinding) {
-                    ForEach(AgeBand.allCases) { band in
-                        Text(band.displayName).tag(band)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .accessibilityIdentifier("settings.ageBand")
-
-                Picker("English level", selection: englishLevelBinding) {
-                    ForEach(EnglishLevel.allCases) { level in
-                        Text(level.displayName).tag(level)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .accessibilityIdentifier("settings.englishLevel")
-
                 TextField("Age (4–16)", text: $ageText)
                     .keyboardType(.numberPad)
                     .focused($isAgeFieldFocused)
@@ -109,28 +93,6 @@ struct SettingsView: View {
         .onAppear {
             ageText = appModel.learnerProfile.age.map(String.init) ?? ""
         }
-    }
-
-    private var ageBandBinding: Binding<AgeBand> {
-        Binding(
-            get: { appModel.onboarding.ageBand ?? .earlyElementary },
-            set: { newValue in
-                var o = appModel.onboarding
-                o.ageBand = newValue
-                appModel.onboarding = o
-            }
-        )
-    }
-
-    private var englishLevelBinding: Binding<EnglishLevel> {
-        Binding(
-            get: { appModel.onboarding.englishLevel ?? .beginner },
-            set: { newValue in
-                var o = appModel.onboarding
-                o.englishLevel = newValue
-                appModel.onboarding = o
-            }
-        )
     }
 
     private var schoolTypeRawBinding: Binding<String> {


### PR DESCRIPTION
Follow-up to #29.

## Why
The request was to **skip onboarding** and take users to Settings (or provide a Settings link). It did *not* ask to move onboarding-specific fields into Settings.

## What changed
- Removed the Age band + English level pickers from `SettingsView`.
- Kept the first-launch Settings sheet behavior (and the rest of Settings).

## Verification
- iOS simulator build: ✅
- `xcodebuild test`: ✅