### PR TITLE
Implement in-app OpenAI key (BYOK) + disable Vercel token service (closes #35)

### DIFF
--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer.xcodeproj/project.pbxproj
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer.xcodeproj/project.pbxproj
@@ -267,19 +267,6 @@
 		};
 /* End PBXShellScriptBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		27A0C0C72F4D4B8B00A22221 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 210056432EFB1FFA005133E6 /* LanguageSpeakingTrainer */;
-			targetProxy = 27A0C0C72F4D4B8B00A11111 /* PBXContainerItemProxy */;
-		};
-		27A0C0C72F4D4B8B00A22222 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 210056432EFB1FFA005133E6 /* LanguageSpeakingTrainer */;
-			targetProxy = 27A0C0C72F4D4B8B00A11112 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin PBXSourcesBuildPhase section */
 		210056402EFB1FFA005133E6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -303,6 +290,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		27A0C0C72F4D4B8B00A22221 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 210056432EFB1FFA005133E6 /* LanguageSpeakingTrainer */;
+			targetProxy = 27A0C0C72F4D4B8B00A11111 /* PBXContainerItemProxy */;
+		};
+		27A0C0C72F4D4B8B00A22222 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 210056432EFB1FFA005133E6 /* LanguageSpeakingTrainer */;
+			targetProxy = 27A0C0C72F4D4B8B00A11112 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		2100564D2EFB1FFC005133E6 /* Debug */ = {

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/AppConfig.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/AppConfig.swift
@@ -12,52 +12,6 @@ enum AppConfig {
         return raw == "1" || raw == "true" || raw == "yes"
     }
 
-    /// Example: https://your-vercel-app.vercel.app
-    static var tokenServiceBaseURL: URL? {
-        // App override (stored locally). This is *not* a secret.
-        if let raw = UserDefaults.standard.string(forKey: "token.service.baseURL.override.v1") {
-            let v = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !v.isEmpty, let url = URL(string: v) {
-                return url
-            }
-        }
-
-        guard
-            let raw = Bundle.main.object(forInfoDictionaryKey: "TOKEN_SERVICE_BASE_URL") as? String,
-            !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
-            return nil
-        }
-        return URL(string: raw)
-    }
-
-    /// Shared secret sent to the token service to protect /api/realtime/token.
-    /// NOTE: This is only MVP protection for a single-user / non-public deployment.
-    static var tokenServiceSharedSecret: String? {
-        // App override (stored securely). Never surface this in UI.
-        if let v = KeychainStore.readString(for: .tokenServiceSharedSecret)?.trimmingCharacters(in: .whitespacesAndNewlines), !v.isEmpty {
-            return v
-        }
-
-        if let raw = Bundle.main.object(forInfoDictionaryKey: "TOKEN_SERVICE_SHARED_SECRET") as? String {
-            let v = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !v.isEmpty {
-                return v
-            }
-        }
-
-        // Dev convenience: allow setting this via Xcode Scheme environment variables
-        // without changing the checked-in Xcode project settings.
-        if let env = ProcessInfo.processInfo.environment["TOKEN_SERVICE_SHARED_SECRET"] {
-            let v = env.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !v.isEmpty {
-                return v
-            }
-        }
-
-        return nil
-    }
-
     /// Standard OpenAI API key used for direct minting (BYOK / dev-only).
     ///
     /// Important: do not ship a production app that relies on a user-entered API key.

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/AppModel.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/AppModel.swift
@@ -270,6 +270,22 @@ final class AppModel: ObservableObject {
         }
     }
 
+    /// Optional local override to avoid having to configure TOKEN_SERVICE_BASE_URL via Xcode.
+    /// This is not a secret and is stored in UserDefaults.
+    @Published var tokenServiceBaseURLOverride: String {
+        didSet {
+            persistTokenServiceBaseURLOverride(tokenServiceBaseURLOverride)
+        }
+    }
+
+    /// Whether a token service shared secret is stored on this device.
+    /// We intentionally never expose the stored value via the UI.
+    @Published private(set) var hasTokenServiceSharedSecret: Bool
+
+    /// Whether an OpenAI API key is stored on this device (BYOK mode).
+    /// We intentionally never expose the stored value via the UI.
+    @Published private(set) var hasOpenAIAPIKey: Bool
+
     @Published var learnerProfile: LearnerProfile {
         didSet {
             let sanitized = learnerProfile.sanitized()
@@ -297,8 +313,15 @@ final class AppModel: ObservableObject {
         let initialRealtimePref = Self.loadRealtimeModelPreference()
         let initialLearnerProfile = LearnerProfile.load()
 
+        let initialBaseURLOverride = Self.loadTokenServiceBaseURLOverride()
+        let initialHasSecret = Self.loadHasTokenServiceSharedSecret()
+        let initialHasOpenAIKey = Self.loadHasOpenAIAPIKey()
+
         onboarding = initialOnboarding
         realtimeModelPreference = initialRealtimePref
+        tokenServiceBaseURLOverride = initialBaseURLOverride
+        hasTokenServiceSharedSecret = initialHasSecret
+        hasOpenAIAPIKey = initialHasOpenAIKey
         learnerProfile = initialLearnerProfile
     }
 
@@ -307,7 +330,12 @@ final class AppModel: ObservableObject {
         defaults.removeObject(forKey: OnboardingSettings.storageKey)
         defaults.removeObject(forKey: LearnerProfile.storageKey)
         defaults.removeObject(forKey: realtimeModelPreferenceKey)
+        defaults.removeObject(forKey: tokenServiceBaseURLOverrideKey)
         defaults.synchronize()
+
+        // Best-effort: also clear Keychain secrets so UITests don't leak state between runs.
+        try? KeychainStore.delete(.tokenServiceSharedSecret)
+        try? KeychainStore.delete(.openAIAPIKey)
     }
 
     var learnerContext: LearnerContext {
@@ -341,6 +369,8 @@ final class AppModel: ObservableObject {
 
     private static let realtimeModelPreferenceKey = "realtime.model.preference.v1"
 
+    private static let tokenServiceBaseURLOverrideKey = "token.service.baseURL.override.v1"
+
     private static func loadRealtimeModelPreference() -> RealtimeModelPreference {
         guard let raw = UserDefaults.standard.string(forKey: realtimeModelPreferenceKey) else {
             return .realtimeMini
@@ -350,6 +380,71 @@ final class AppModel: ObservableObject {
 
     private func persistRealtimeModelPreference(_ pref: RealtimeModelPreference) {
         UserDefaults.standard.set(pref.rawValue, forKey: Self.realtimeModelPreferenceKey)
+    }
+
+    private static func loadTokenServiceBaseURLOverride() -> String {
+        let raw = UserDefaults.standard.string(forKey: tokenServiceBaseURLOverrideKey) ?? ""
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func persistTokenServiceBaseURLOverride(_ raw: String) {
+        let v = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if v.isEmpty {
+            UserDefaults.standard.removeObject(forKey: Self.tokenServiceBaseURLOverrideKey)
+        } else {
+            UserDefaults.standard.set(v, forKey: Self.tokenServiceBaseURLOverrideKey)
+        }
+    }
+
+    private static func loadHasTokenServiceSharedSecret() -> Bool {
+        let v = KeychainStore.readString(for: .tokenServiceSharedSecret)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return !v.isEmpty
+    }
+
+    private static func loadHasOpenAIAPIKey() -> Bool {
+        let v = KeychainStore.readString(for: .openAIAPIKey)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return !v.isEmpty
+    }
+
+    func storeTokenServiceSharedSecret(_ secret: String) {
+        let v = secret.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !v.isEmpty else { return }
+        do {
+            try KeychainStore.writeString(v, for: .tokenServiceSharedSecret)
+            hasTokenServiceSharedSecret = true
+        } catch {
+            // Intentionally do not log the secret.
+            // For now we silently ignore; can be surfaced in UI later if needed.
+        }
+    }
+
+    func clearTokenServiceSharedSecret() {
+        do {
+            try KeychainStore.delete(.tokenServiceSharedSecret)
+        } catch {
+            // Ignore failures; we still recompute.
+        }
+        hasTokenServiceSharedSecret = Self.loadHasTokenServiceSharedSecret()
+    }
+
+    func storeOpenAIAPIKey(_ apiKey: String) {
+        let v = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !v.isEmpty else { return }
+        do {
+            try KeychainStore.writeString(v, for: .openAIAPIKey)
+            hasOpenAIAPIKey = true
+        } catch {
+            // Intentionally do not log the key.
+        }
+    }
+
+    func clearOpenAIAPIKey() {
+        do {
+            try KeychainStore.delete(.openAIAPIKey)
+        } catch {
+            // Ignore failures; we still recompute.
+        }
+        hasOpenAIAPIKey = Self.loadHasOpenAIAPIKey()
     }
 }
 

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/KeychainStore.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/KeychainStore.swift
@@ -7,7 +7,6 @@ import Security
 /// The app still needs read access internally to make authenticated requests.
 enum KeychainStore {
     enum SecretKey: String {
-        case tokenServiceSharedSecret = "token_service_shared_secret"
         // Reserved for future BYOK support:
         case openAIAPIKey = "openai_api_key"
     }

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/KeychainStore.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/KeychainStore.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Security
+
+/// Minimal Keychain wrapper for storing small secrets.
+///
+/// Design goal: callers should treat values as *write-only* at the UI level.
+/// The app still needs read access internally to make authenticated requests.
+enum KeychainStore {
+    enum SecretKey: String {
+        case tokenServiceSharedSecret = "token_service_shared_secret"
+        // Reserved for future BYOK support:
+        case openAIAPIKey = "openai_api_key"
+    }
+
+    private static var service: String {
+        Bundle.main.bundleIdentifier ?? "LanguageSpeakingTrainer"
+    }
+
+    static func readString(for key: SecretKey) -> String? {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: true,
+        ]
+
+        // Allow reads from the foreground; do not require user presence.
+        // (This is a dev convenience; for higher security, consider access control flags.)
+        query[kSecUseDataProtectionKeychain as String] = true
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess else {
+            return nil
+        }
+        guard let data = item as? Data else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func writeString(_ value: String, for key: SecretKey) throws {
+        let data = Data(value.utf8)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+            kSecUseDataProtectionKeychain as String: true,
+        ]
+
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            // Keep the secret only on this device.
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
+
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return
+        }
+        if updateStatus != errSecItemNotFound {
+            throw KeychainError(status: updateStatus)
+        }
+
+        var addQuery = query
+        for (k, v) in attributes {
+            addQuery[k] = v
+        }
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw KeychainError(status: addStatus)
+        }
+    }
+
+    static func delete(_ key: SecretKey) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+            kSecUseDataProtectionKeychain as String: true,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        if status == errSecSuccess || status == errSecItemNotFound {
+            return
+        }
+        throw KeychainError(status: status)
+    }
+}
+
+struct KeychainError: Error {
+    let status: OSStatus
+}

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/OpenAIRealtimeWebRTCClient.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/OpenAIRealtimeWebRTCClient.swift
@@ -36,10 +36,10 @@ final class OpenAIRealtimeWebRTCClient: RealtimeSessionClient {
             do {
                 #if DEBUG && canImport(WebRTC)
                 // Log configuration info to OSLog for debugging (not visible in UI)
-                if let base = AppConfig.tokenServiceBaseURL {
-                    logger.debug("Token service configured: \(base.absoluteString, privacy: .public)")
+                if AppConfig.openAIAPIKey != nil {
+                    logger.debug("OpenAI BYOK key is configured (will mint client secrets directly)")
                 } else {
-                    logger.warning("Token service not configured (missing TOKEN_SERVICE_BASE_URL in Info.plist)")
+                    logger.warning("OpenAI BYOK key is not configured (Settings → OpenAI (BYOK))")
                 }
                 #endif
 

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift
@@ -7,7 +7,6 @@ struct SettingsView: View {
     @State private var ageError: String? = nil
     @FocusState private var isAgeFieldFocused: Bool
 
-    @State private var tokenServiceSharedSecretDraft: String = ""
     @State private var openAIAPIKeyDraft: String = ""
 
     var body: some View {
@@ -84,60 +83,6 @@ struct SettingsView: View {
             }
 
             Section {
-                TextField("Token service base URL", text: $appModel.tokenServiceBaseURLOverride)
-                    .keyboardType(.URL)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-
-                Text("Example: https://your-vercel-app.vercel.app")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-
-                Divider()
-
-                if appModel.hasTokenServiceSharedSecret {
-                    LabeledContent("Shared secret") {
-                        Text("Saved")
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    LabeledContent("Shared secret") {
-                        Text("Not set")
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                SecureField(appModel.hasTokenServiceSharedSecret ? "Enter new shared secret" : "Enter shared secret", text: $tokenServiceSharedSecretDraft)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .textContentType(.password)
-
-                HStack {
-                    Button("Save") {
-                        appModel.storeTokenServiceSharedSecret(tokenServiceSharedSecretDraft)
-                        tokenServiceSharedSecretDraft = ""
-                    }
-                    .disabled(tokenServiceSharedSecretDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-                    Spacer()
-
-                    Button("Clear", role: .destructive) {
-                        appModel.clearTokenServiceSharedSecret()
-                        tokenServiceSharedSecretDraft = ""
-                    }
-                    .disabled(!appModel.hasTokenServiceSharedSecret)
-                }
-
-                Text("For safety, the stored secret cannot be displayed again. To change it, enter a new value and tap Save.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            } header: {
-                Text("Token service")
-            } footer: {
-                Text("If a secret is stored here, the app will use it for /api/realtime/token requests instead of Info.plist or Xcode scheme environment variables.")
-            }
-
-            Section {
                 if appModel.hasOpenAIAPIKey {
                     LabeledContent("API key") {
                         Text("Saved")
@@ -177,7 +122,7 @@ struct SettingsView: View {
             } header: {
                 Text("OpenAI (BYOK)")
             } footer: {
-                Text("Dev/personal use only: storing an API key on-device can be risky. If a key is set here, the app will mint Realtime client secrets directly from OpenAI and will not require the Vercel token service.")
+                Text("Dev/personal use only: storing an API key on-device can be risky. If a key is set here, the app will mint Realtime client secrets directly from OpenAI.")
             }
         }
         .navigationTitle("Settings")

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/SettingsView.swift
@@ -7,6 +7,9 @@ struct SettingsView: View {
     @State private var ageError: String? = nil
     @FocusState private var isAgeFieldFocused: Bool
 
+    @State private var tokenServiceSharedSecretDraft: String = ""
+    @State private var openAIAPIKeyDraft: String = ""
+
     var body: some View {
         Form {
             Section {
@@ -78,6 +81,103 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             } header: {
                 Text("Learner")
+            }
+
+            Section {
+                TextField("Token service base URL", text: $appModel.tokenServiceBaseURLOverride)
+                    .keyboardType(.URL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+
+                Text("Example: https://your-vercel-app.vercel.app")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                Divider()
+
+                if appModel.hasTokenServiceSharedSecret {
+                    LabeledContent("Shared secret") {
+                        Text("Saved")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    LabeledContent("Shared secret") {
+                        Text("Not set")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                SecureField(appModel.hasTokenServiceSharedSecret ? "Enter new shared secret" : "Enter shared secret", text: $tokenServiceSharedSecretDraft)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textContentType(.password)
+
+                HStack {
+                    Button("Save") {
+                        appModel.storeTokenServiceSharedSecret(tokenServiceSharedSecretDraft)
+                        tokenServiceSharedSecretDraft = ""
+                    }
+                    .disabled(tokenServiceSharedSecretDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    Spacer()
+
+                    Button("Clear", role: .destructive) {
+                        appModel.clearTokenServiceSharedSecret()
+                        tokenServiceSharedSecretDraft = ""
+                    }
+                    .disabled(!appModel.hasTokenServiceSharedSecret)
+                }
+
+                Text("For safety, the stored secret cannot be displayed again. To change it, enter a new value and tap Save.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text("Token service")
+            } footer: {
+                Text("If a secret is stored here, the app will use it for /api/realtime/token requests instead of Info.plist or Xcode scheme environment variables.")
+            }
+
+            Section {
+                if appModel.hasOpenAIAPIKey {
+                    LabeledContent("API key") {
+                        Text("Saved")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    LabeledContent("API key") {
+                        Text("Not set")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                SecureField(appModel.hasOpenAIAPIKey ? "Enter new OpenAI API key" : "Enter OpenAI API key", text: $openAIAPIKeyDraft)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textContentType(.password)
+
+                HStack {
+                    Button("Save") {
+                        appModel.storeOpenAIAPIKey(openAIAPIKeyDraft)
+                        openAIAPIKeyDraft = ""
+                    }
+                    .disabled(openAIAPIKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    Spacer()
+
+                    Button("Clear", role: .destructive) {
+                        appModel.clearOpenAIAPIKey()
+                        openAIAPIKeyDraft = ""
+                    }
+                    .disabled(!appModel.hasOpenAIAPIKey)
+                }
+
+                Text("For safety, the stored key cannot be displayed again. To change it, enter a new value and tap Save.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text("OpenAI (BYOK)")
+            } footer: {
+                Text("Dev/personal use only: storing an API key on-device can be risky. If a key is set here, the app will mint Realtime client secrets directly from OpenAI and will not require the Vercel token service.")
             }
         }
         .navigationTitle("Settings")

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/TokenService.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/TokenService.swift
@@ -7,8 +7,6 @@ struct EphemeralTokenResponse: Decodable {
 
 enum TokenServiceError: Error {
     case missingOpenAIAPIKey
-    case missingBaseURL
-    case missingSharedSecret
     case invalidResponse
     case httpError(status: Int, body: String)
 }
@@ -18,10 +16,6 @@ extension TokenServiceError: LocalizedError {
         switch self {
         case .missingOpenAIAPIKey:
             return "Missing OpenAI API key. Set it in Settings (OpenAI BYOK), or configure OPENAI_API_KEY as an Xcode Scheme environment variable."
-        case .missingBaseURL:
-            return "Missing TOKEN_SERVICE_BASE_URL. Set it in the app target Build Settings (User-Defined) or in Info.plist via the Info.plist template. Example: https://your-vercel-app.vercel.app"
-        case .missingSharedSecret:
-            return "Missing TOKEN_SERVICE_SHARED_SECRET. Set it as an Xcode Scheme environment variable (Run → Arguments → Environment Variables) named TOKEN_SERVICE_SHARED_SECRET, or set the app target Build Setting TOKEN_SERVICE_SHARED_SECRET so Info.plist can expand $(TOKEN_SERVICE_SHARED_SECRET)."
         case .invalidResponse:
             return "Invalid response from token service"
         case .httpError(let status, let body):
@@ -39,61 +33,16 @@ enum TokenService {
         learner: String? = nil,
         mode: RealtimeModelPreference = .realtimeMini
     ) async throws -> EphemeralTokenResponse {
-        // If an on-device OpenAI key is configured, bypass the token service and mint directly.
-        if let apiKey = AppConfig.openAIAPIKey {
-            return try await OpenAIDirectTokenMinter.mintClientSecret(
-                apiKey: apiKey,
-                topic: topic,
-                learner: learner,
-                mode: mode
-            )
+        guard let apiKey = AppConfig.openAIAPIKey else {
+            throw TokenServiceError.missingOpenAIAPIKey
         }
 
-        guard let base = AppConfig.tokenServiceBaseURL else {
-            throw TokenServiceError.missingBaseURL
-        }
-
-        guard let sharedSecret = AppConfig.tokenServiceSharedSecret else {
-            throw TokenServiceError.missingSharedSecret
-        }
-
-        // NOTE: Do not include a leading "/" in `appendingPathComponent`.
-        // A leading slash can become percent-encoded and produce URLs like:
-        //   https://example.com/%2Fapi%2Frealtime%2Ftoken
-        let tokenURL = base
-            .appendingPathComponent("api")
-            .appendingPathComponent("realtime")
-            .appendingPathComponent("token")
-
-        var components = URLComponents(url: tokenURL, resolvingAgainstBaseURL: false)
-        var queryItems: [URLQueryItem] = [
-            URLQueryItem(name: "mode", value: mode.rawValue)
-        ]
-        if let topic {
-            queryItems.append(URLQueryItem(name: "topic", value: topic.title))
-        }
-        if let learner, !learner.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            queryItems.append(URLQueryItem(name: "learner", value: learner))
-        }
-        components?.queryItems = queryItems
-        guard let url = components?.url else { throw TokenServiceError.invalidResponse }
-
-        var req = URLRequest(url: url)
-        req.httpMethod = "GET"
-        req.cachePolicy = .reloadIgnoringLocalCacheData
-        req.setValue(sharedSecret, forHTTPHeaderField: "X-Token-Service-Secret")
-
-        let (data, resp) = try await URLSession.shared.data(for: req)
-        guard let http = resp as? HTTPURLResponse else {
-            throw TokenServiceError.invalidResponse
-        }
-        guard (200..<300).contains(http.statusCode) else {
-            // Best-effort debugging help.
-            let body = String(data: data, encoding: .utf8) ?? ""
-            throw TokenServiceError.httpError(status: http.statusCode, body: body)
-        }
-
-        return try JSONDecoder().decode(EphemeralTokenResponse.self, from: data)
+        return try await OpenAIDirectTokenMinter.mintClientSecret(
+            apiKey: apiKey,
+            topic: topic,
+            learner: learner,
+            mode: mode
+        )
     }
 }
 

--- a/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/TokenService.swift
+++ b/ios/App/LanguageSpeakingTrainer/LanguageSpeakingTrainer/TokenService.swift
@@ -6,6 +6,7 @@ struct EphemeralTokenResponse: Decodable {
 }
 
 enum TokenServiceError: Error {
+    case missingOpenAIAPIKey
     case missingBaseURL
     case missingSharedSecret
     case invalidResponse
@@ -15,6 +16,8 @@ enum TokenServiceError: Error {
 extension TokenServiceError: LocalizedError {
     var errorDescription: String? {
         switch self {
+        case .missingOpenAIAPIKey:
+            return "Missing OpenAI API key. Set it in Settings (OpenAI BYOK), or configure OPENAI_API_KEY as an Xcode Scheme environment variable."
         case .missingBaseURL:
             return "Missing TOKEN_SERVICE_BASE_URL. Set it in the app target Build Settings (User-Defined) or in Info.plist via the Info.plist template. Example: https://your-vercel-app.vercel.app"
         case .missingSharedSecret:
@@ -36,6 +39,16 @@ enum TokenService {
         learner: String? = nil,
         mode: RealtimeModelPreference = .realtimeMini
     ) async throws -> EphemeralTokenResponse {
+        // If an on-device OpenAI key is configured, bypass the token service and mint directly.
+        if let apiKey = AppConfig.openAIAPIKey {
+            return try await OpenAIDirectTokenMinter.mintClientSecret(
+                apiKey: apiKey,
+                topic: topic,
+                learner: learner,
+                mode: mode
+            )
+        }
+
         guard let base = AppConfig.tokenServiceBaseURL else {
             throw TokenServiceError.missingBaseURL
         }
@@ -82,4 +95,133 @@ enum TokenService {
 
         return try JSONDecoder().decode(EphemeralTokenResponse.self, from: data)
     }
+}
+
+private enum OpenAIDirectTokenMinter {
+    private struct OpenAIClientSecretResponse: Decodable {
+        let value: String
+        let expires_at: Int?
+    }
+
+    // Mirrors the backend's request body, but is client-owned for BYOK mode.
+    private struct RequestBody: Encodable {
+        struct ExpiresAfter: Encodable {
+            let anchor: String
+            let seconds: Int
+        }
+        struct Session: Encodable {
+            struct Audio: Encodable {
+                struct Output: Encodable {
+                    let voice: String
+                }
+                let output: Output
+            }
+
+            let type: String
+            let model: String
+            let instructions: String
+            let audio: Audio
+        }
+
+        let expires_after: ExpiresAfter
+        let session: Session
+    }
+
+    static func mintClientSecret(
+        apiKey: String,
+        topic: Topic?,
+        learner: String?,
+        mode: RealtimeModelPreference
+    ) async throws -> EphemeralTokenResponse {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else {
+            throw TokenServiceError.missingOpenAIAPIKey
+        }
+
+        // Keep the mapping explicit and consistent with the backend defaults.
+        let modelId: String
+        switch mode {
+        case .realtime:
+            modelId = "gpt-realtime"
+        case .realtimeMini:
+            modelId = "gpt-realtime-mini"
+        }
+
+        // Keep these aligned with backend defaults. (Can be made configurable later.)
+        let ttlSeconds = 600
+        let voice = "alloy"
+
+        var instructions = OpenAIRealtimeInstructions.base
+        if let learner, !learner.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            instructions += "\n\n\(learner)"
+        }
+        if let topic {
+            instructions += "\n\nSelected topic: \(topic.title)"
+        }
+
+        let body = RequestBody(
+            expires_after: .init(anchor: "created_at", seconds: max(60, min(ttlSeconds, 3600))),
+            session: .init(
+                type: "realtime",
+                model: modelId,
+                instructions: instructions,
+                audio: .init(output: .init(voice: voice))
+            )
+        )
+
+        guard let url = URL(string: "https://api.openai.com/v1/realtime/client_secrets") else {
+            throw TokenServiceError.invalidResponse
+        }
+
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.cachePolicy = .reloadIgnoringLocalCacheData
+        req.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONEncoder().encode(body)
+
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        guard let http = resp as? HTTPURLResponse else {
+            throw TokenServiceError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let bodyText = String(data: data, encoding: .utf8) ?? ""
+            throw TokenServiceError.httpError(status: http.statusCode, body: bodyText)
+        }
+
+        let decoded = try JSONDecoder().decode(OpenAIClientSecretResponse.self, from: data)
+        return EphemeralTokenResponse(value: decoded.value, expires_at: decoded.expires_at)
+    }
+}
+
+private enum OpenAIRealtimeInstructions {
+    // Kept in sync with `api/realtime/token.js` SYSTEM_INSTRUCTIONS.
+    static let base = """
+You are a friendly English teacher for children.
+
+Hard rules (safety & privacy):
+- Keep language age-appropriate, positive, and kind.
+- Never ask for personal identifying info (full name, address, phone, school, exact location, social handles).
+- If the child shares personal info, do not repeat it and do not ask follow-ups; gently redirect to the topic.
+- If the child requests unsafe content, refuse briefly and offer a safe alternative.
+
+Conversation rules:
+- Stay on the selected topic. If the child changes topic, gently guide back.
+- Ask at most one question at a time.
+- Keep your turns short (1–3 sentences).
+
+Teaching style (make the child talk more):
+- Goal: the child should speak about 75% of the time (you speak about 25%).
+- To achieve this, keep each teacher turn very short (1–2 sentences), then prompt the child and wait.
+- Prefer easy prompts that invite speaking: yes/no, A/B choices, or a short open question.
+- Give wait-time: if the child is quiet, respond supportively and offer a simpler choice question.
+- Use scaffolding: give a sentence starter the child can complete (e.g., “I like ___ because ___.").
+- Use gentle feedback: praise effort first, then (if needed) give at most one simple correction.
+- When correcting: show one short improved example and invite the child to try again.
+- Use recasts naturally (repeat their idea in correct English without making them feel wrong).
+- Occasionally do retrieval practice: later in the chat, ask them to say the same useful phrase again.
+
+Session start:
+- Greet first and ask one simple question about the selected topic.
+"""
 }

--- a/ios/README.md
+++ b/ios/README.md
@@ -32,6 +32,16 @@ Optional (for later Realtime token minting):
 - `TOKEN_SERVICE_BASE_URL`: `https://your-vercel-app.vercel.app`
 - `TOKEN_SERVICE_SHARED_SECRET`: a shared secret that the backend requires on `/api/realtime/token`
 
+Alternative (dev/personal use): **BYOK (Bring Your Own Key)**
+
+- You can enter an **OpenAI API key directly in the app** under **Settings → OpenAI (BYOK)**.
+- The key is stored in the **Keychain** and is **write-only** from the UI (it cannot be displayed again after saving).
+- When a BYOK key is set, the app will mint Realtime client secrets **directly from OpenAI** and does **not** require the Vercel token service.
+
+Security warning:
+
+- Storing an API key on-device is risky and not suitable for a public/shipped app. Treat BYOK as a personal/dev convenience only.
+
 How to set these (recommended for local dev):
 
 1. In Xcode, select the app scheme → **Edit Scheme…**

--- a/ios/README.md
+++ b/ios/README.md
@@ -7,7 +7,7 @@ This folder contains the native iOS (SwiftUI) implementation for **Language Spea
 - SwiftUI app skeleton is implemented (onboarding → home → session).
 - Microphone permission + local mic level monitoring (for the “mic activity animation” requirement) is included.
 - OpenAI Realtime (WebRTC) is **not fully wired yet**.
-  - If `TOKEN_SERVICE_BASE_URL` is set, the app will attempt to use the realtime client and fetch an ephemeral token.
+  - The app mints ephemeral Realtime client secrets **directly from OpenAI** when an API key is configured.
   - Actual WebRTC audio requires adding a WebRTC SDK module named `WebRTC` to the Xcode project.
 
 ## Prerequisites
@@ -27,39 +27,24 @@ Template value suggestion:
 
 - `NSMicrophoneUsageDescription`: "We use the microphone so you can practice speaking English with your virtual teacher."
 
-Optional (for later Realtime token minting):
-
-- `TOKEN_SERVICE_BASE_URL`: `https://your-vercel-app.vercel.app`
-- `TOKEN_SERVICE_SHARED_SECRET`: a shared secret that the backend requires on `/api/realtime/token`
-
-Alternative (dev/personal use): **BYOK (Bring Your Own Key)**
+Realtime token minting: **BYOK (Bring Your Own Key)**
 
 - You can enter an **OpenAI API key directly in the app** under **Settings → OpenAI (BYOK)**.
 - The key is stored in the **Keychain** and is **write-only** from the UI (it cannot be displayed again after saving).
-- When a BYOK key is set, the app will mint Realtime client secrets **directly from OpenAI** and does **not** require the Vercel token service.
+- With a BYOK key set, the app will mint Realtime client secrets **directly from OpenAI**.
 
-Security warning:
+How to set this (recommended for local dev):
 
-- Storing an API key on-device is risky and not suitable for a public/shipped app. Treat BYOK as a personal/dev convenience only.
+1. Run the app.
+2. Open **Settings**.
+3. Under **OpenAI (BYOK)**, paste your OpenAI API key and tap **Save**.
 
-How to set these (recommended for local dev):
-
-1. In Xcode, select the app scheme → **Edit Scheme…**
-2. Run → **Arguments** → **Environment Variables**
-3. Add:
-
-- `TOKEN_SERVICE_BASE_URL` (example: `https://language-speaking-trainer.vercel.app`)
-- `TOKEN_SERVICE_SHARED_SECRET` (must match the backend `TOKEN_SERVICE_SHARED_SECRET`)
-
-Alternative: set these as **User-Defined** Build Settings on the app target (so the Info.plist entries can expand `$(TOKEN_SERVICE_BASE_URL)` and `$(TOKEN_SERVICE_SHARED_SECRET)`).
-
-Note: This is MVP protection suitable for a single-user/private deployment. For a public app, a shipped secret can be extracted.
+Alternative (Xcode env var): set `OPENAI_API_KEY` as a Run environment variable.
 
 Note: there is an older scaffold folder at `ios/LanguageSpeakingTrainer/` from before the `.xcodeproj` existed. The canonical sources going forward are the ones inside the Xcode project folder under `ios/App/...`.
 
 ## Next steps
 
-- Add Vercel token endpoint config + fetch.
 - Implement OpenAI Realtime WebRTC connection.
 - Replace mock teacher messages with realtime audio + transcripts.
 


### PR DESCRIPTION
Closes #35.

## Summary
- Add **Settings → OpenAI (BYOK)** to enter an OpenAI API key directly in-app.
- Store the key in **Keychain** and keep it **write-only in UI** (cannot be displayed after saving).
- Mint Realtime client secrets **directly from OpenAI** on-device.
- **Disable the Vercel token service flow completely** in the iOS app (no fallback, no token-service settings).

## Notes
- BYOK is intended for dev/personal use. Storing API keys on-device is not suitable for a public app.

## Testing
- iOS simulator build succeeded via `xcodebuild` (Debug, iPhone 17 simulator).